### PR TITLE
avoid closing of classloader by returning a delegate

### DIFF
--- a/src/main/java/org/phidias/compile/BundleJavaManager.java
+++ b/src/main/java/org/phidias/compile/BundleJavaManager.java
@@ -139,7 +139,7 @@ public class BundleJavaManager
 	}
 
 	public ClassLoader getClassLoader() {
-		return _classLoader;
+		return new DelegatingClassLoader(_classLoader);
 	}
 
 	@Override
@@ -425,4 +425,12 @@ public class BundleJavaManager
 	private BundleWiring _systemBundleWiring;
 	private List<BundleCapability> _systemCapabilities;
 
+	private class DelegatingClassLoader extends ClassLoader {
+
+		public DelegatingClassLoader(ClassLoader parent) {
+			super(parent);
+		}
+		
+	}
+	
 }


### PR DESCRIPTION
If annotation processors are enabled (e.g. without proc:none option) or if JDK14 is used (see [this commit](https://github.com/openjdk/jdk/commit/45b8d09e1bc2e41ddda79ac7881d840eb6e2d49a#diff-9e2cb35800962620a93374e3ac40351dL211)), then when closeable, the class loader of the bundle wiring of the bundle doing the compiling (`bundle.adapt(BundleWiring.class).getClassLoader()`) will be closed on `JavaCompiler` task `call`.

An example with different compile options and a mocked `Bundle` :
[DemoClassLoaderClosing.zip](https://github.com/rotty3000/phidias/files/5028640/DemoClassLoaderClosing.zip)

